### PR TITLE
Util refactor

### DIFF
--- a/parse-argv.sh
+++ b/parse-argv.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -e
+
+# shellcheck disable=SC1091
+source ./util.sh
+
+function parse-argv {
+    :
+}

--- a/parse-options.sh
+++ b/parse-options.sh
@@ -27,11 +27,11 @@ function print-options-table {
     for e in "${defaults[@]}"; do if [[ "${#e}" -gt "$width_default" ]]; then width_default="${#e}"; fi; done
 
     local -a column_spec=( \
-        "$header_idx" "$width_idx" \
-        "$header_short" "$width_short" \
-        "$header_long" "$width_long" \
+        "$header_idx"      "$width_idx" \
+        "$header_short"    "$width_short" \
+        "$header_long"     "$width_long" \
         "$header_argument" "$width_argument" \
-        "$header_default" "$width_default"
+        "$header_default"  "$width_default"
     )
 
     print_table_header column_spec
@@ -46,7 +46,7 @@ function print-options-table {
         print_table_row column_spec
     done
 
-    print_table_line column_spec
+    print_table_hr column_spec
 }
 
 function parse-options {

--- a/parse-options.sh
+++ b/parse-options.sh
@@ -13,35 +13,40 @@ function print-options-table {
           header_argument='ARG' \
           header_default='DEFAULT'
 
-    local max_idx=${#header_idx} \
-          max_short=${#header_short} \
-          max_long=${#header_long} \
-          max_argument=${#header_argument} \
-          max_default=${#header_default} \
-          line line1 line2 line3 line4 line5
+    local width_idx=${#header_idx} \
+          width_short=${#header_short} \
+          width_long=${#header_long} \
+          width_argument=${#header_argument} \
+          width_default=${#header_default}
 
     local e i
-    for e in "${!longs[@]}"; do if [[ "${#e}" -gt "$max_idx" ]]; then max_idx="${#e}"; fi; done
-    for e in "${shorts[@]}"; do if [[ "${#e}" -gt "$max_short" ]]; then max_short="${#e}"; fi; done
-    for e in "${longs[@]}"; do if [[ "${#e}" -gt "$max_long" ]]; then max_long="${#e}"; fi; done
-    for e in "${arguments[@]}"; do if [[ "${#e}" -gt "$max_argument" ]]; then max_argument="${#e}"; fi; done
-    for e in "${defaults[@]}"; do if [[ "${#e}" -gt "$max_default" ]]; then max_default="${#e}"; fi; done
+    for e in "${!longs[@]}"; do if [[ "${#e}" -gt "$width_idx" ]]; then width_idx="${#e}"; fi; done
+    for e in "${shorts[@]}"; do if [[ "${#e}" -gt "$width_short" ]]; then width_short="${#e}"; fi; done
+    for e in "${longs[@]}"; do if [[ "${#e}" -gt "$width_long" ]]; then width_long="${#e}"; fi; done
+    for e in "${arguments[@]}"; do if [[ "${#e}" -gt "$width_argument" ]]; then width_argument="${#e}"; fi; done
+    for e in "${defaults[@]}"; do if [[ "${#e}" -gt "$width_default" ]]; then width_default="${#e}"; fi; done
 
-    printf -v line1 -- "%0.1s" $(eval echo "-"{0..$((max_idx + 1))});
-    printf -v line2 -- "%0.1s" $(eval echo "-"{0..$((max_short + 1))});
-    printf -v line3 -- "%0.1s" $(eval echo "-"{0..$((max_long + 1))});
-    printf -v line4 -- "%0.1s" $(eval echo "-"{0..$((max_argument + 1))});
-    printf -v line5 -- "%0.1s" $(eval echo "-"{0..$((max_default + 1))})
-    printf -v line -- '+%s+%s+%s+%s+%s+' "$line1" "$line2" "$line3" "$line4" "$line5"
+    local -a column_spec=( \
+        "$header_idx" "$width_idx" \
+        "$header_short" "$width_short" \
+        "$header_long" "$width_long" \
+        "$header_argument" "$width_argument" \
+        "$header_default" "$width_default"
+    )
 
-    printf '%s\n' "$line"
-    printf -- "| % ${max_idx}s | % ${max_short}s | % ${max_long}s | % ${max_argument}s | % ${max_default}s |\n" "$header_idx" "$header_short" "$header_long" "$header_argument" "$header_default"
-    printf '%s\n' "$line"
+    print_table_header column_spec
 
     for i in "${!longs[@]}"; do
-        printf "| % ${max_idx}s | % ${max_short}s | % ${max_long}s | % ${max_argument}s | % ${max_default}s |\n" "$i" "${shorts[i]}" "${longs[i]}" "${arguments[i]}" "${defaults[i]}"
+        column_spec[0]="$i"
+        column_spec[2]="${shorts[i]}"
+        column_spec[4]="${longs[i]}"
+        column_spec[6]="${arguments[i]}"
+        # shellcheck disable=SC2034
+        column_spec[8]="${defaults[i]}"
+        print_table_row column_spec
     done
-    printf '%s\n' "$line"
+
+    print_table_line column_spec
 }
 
 function parse-options {

--- a/test.sh
+++ b/test.sh
@@ -54,9 +54,10 @@ function run-test {
                                                 "$output4" "$output5" "$output6" "$output7"
 
     if [[ "$snaphot" != "$test_result" ]]; then
-        printf ' failed!\n\nTest: %s did not match snapshot\n\n' "$test_file"
-        printf 'Expected:\n%s\n\n' "$snaphot"
-        printf 'Got:\n%s\n' "$test_result"
+        printf ' failed!\n\nTest: %s did not match snapshot\n\n' "$test_file" >&2
+        diff -Naur <(printf '%s' "$snaphot") <(printf '%s' "$test_result") >&2
+        # printf 'Expected:\n%s\n\n' "$snaphot"
+        # printf 'Got:\n%s\n' "$test_result"
         exit 1
     else
         printf ' pass.\n'

--- a/util.sh
+++ b/util.sh
@@ -65,3 +65,51 @@ function debug_line_printf {
         DEBUG=$old
     fi
 }
+
+function print_table_header {
+    local work line header column width
+    local -n _column_spec
+
+    _column_spec=$1
+    while read -r column width; do
+        # shellcheck disable=SC2046 disable=SC1083 disable=SC2175
+        printf -v work -- '%0.1s' $(eval echo "-"{0..$((width + 1))});
+        line+="$work"
+        # shellcheck disable=SC2046 disable=SC1083 disable=SC2175
+        printf -v work -- "| % ${width}s " "$column"
+        header+="$work"
+    done <<< "${_column_spec[@]}"
+
+    printf -- '%s+\n' "$line"
+    printf -- '%s|\n' "$header"
+    printf -- '%s+\n' "$line"
+}
+
+function print_table_row {
+    local work row column width
+    local -n _column_spec
+
+    _column_spec=$1
+    while read -r column width; do
+        # shellcheck disable=SC2046 disable=SC1083 disable=SC2175
+        printf -v work -- "| % ${width}s " "$column"
+        row+="$work"
+    done <<< "${_column_spec[@]}"
+
+    printf -- '%s|\n' "$row"
+}
+
+function print_table_line {
+    local work line _ width
+    local -n _column_spec
+
+    _column_spec=$1
+    while read -r _ width; do
+        # shellcheck disable=SC2046 disable=SC1083 disable=SC2175
+        printf -v work -- '%0.1s' $(eval echo "-"{0..$((width + 1))});
+        line+="$work"
+    done <<< "${_column_spec[@]}"
+
+    printf -- '%s+\n' "$line"
+}
+

--- a/util.sh
+++ b/util.sh
@@ -67,18 +67,20 @@ function debug_line_printf {
 }
 
 function print_table_header {
-    local work line header column width
+    local work line header column width i
     local -n _column_spec
 
     _column_spec=$1
-    while read -r column width; do
+    for ((i = 0; i < ${#_column_spec[@]}; i += 2 )); do
+        column="${_column_spec[i]}"
+        width="${_column_spec[i+1]}"
         # shellcheck disable=SC2046 disable=SC1083 disable=SC2175
         printf -v work -- '%0.1s' $(eval echo "-"{0..$((width + 1))});
-        line+="$work"
+        line+="+$work"
         # shellcheck disable=SC2046 disable=SC1083 disable=SC2175
         printf -v work -- "| % ${width}s " "$column"
         header+="$work"
-    done <<< "${_column_spec[@]}"
+    done
 
     printf -- '%s+\n' "$line"
     printf -- '%s|\n' "$header"
@@ -86,29 +88,32 @@ function print_table_header {
 }
 
 function print_table_row {
-    local work row column width
+    local work row column width i
     local -n _column_spec
 
     _column_spec=$1
-    while read -r column width; do
+    for (( i = 0; i < ${#_column_spec[@]}; i += 2 )); do
+        column="${_column_spec[i]}"
+        width="${_column_spec[i+1]}"
         # shellcheck disable=SC2046 disable=SC1083 disable=SC2175
         printf -v work -- "| % ${width}s " "$column"
         row+="$work"
-    done <<< "${_column_spec[@]}"
+    done
 
     printf -- '%s|\n' "$row"
 }
 
-function print_table_line {
-    local work line _ width
+function print_table_hr {
+    local work line width i
     local -n _column_spec
 
     _column_spec=$1
-    while read -r _ width; do
+    for ((i = 0; i < ${#_column_spec[@]}; i += 2 )); do
+        width="${_column_spec[i+1]}"
         # shellcheck disable=SC2046 disable=SC1083 disable=SC2175
         printf -v work -- '%0.1s' $(eval echo "-"{0..$((width + 1))});
-        line+="$work"
-    done <<< "${_column_spec[@]}"
+        line+="+$work"
+    done
 
     printf -- '%s+\n' "$line"
 }


### PR DESCRIPTION
Refactor the print utility functions, so it they don't clutter the print table functions (used in snapshots and tests in general) with unnecessary string formatting code.